### PR TITLE
{%include%} syntax doesn't work with Github Pages. It needs an overhaul

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,10 +31,10 @@
     </style>
 </head>
 <body>
-    {% include header.html %}
+    {% render 'header.html' %}
     <main>
         {{ content }}
     </main>
-    {% include footer.html %}
+    {% render 'footer.html' %}
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@1.5.5/css/pico.min.css">
 </head>
 <body>
-    {% include header.html %}
-    {% include main.html %}
-    {% include footer.html %}
+    {% render 'header.html' %}
+    {% render 'main.html' %}
+    {% render 'footer.html' %}
 </body>
 </html>

--- a/learning-pygame-zero.html
+++ b/learning-pygame-zero.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@1.5.5/css/pico.min.css">
 </head>
 <body>
-    {% include header.html %}
-    {% include main.html %}
-    {% include footer.html %}
+    {% render 'header.html' %}
+    {% render 'main.html' %}
+    {% render 'footer.html' %}
 </body>
 </html>


### PR DESCRIPTION
Update include syntax to render syntax for GitHub Pages compatibility.

* Replace `{% include header.html %}` with `{% render 'header.html' %}` in `index.html`, `learning-pygame-zero.html`, and `_layouts/default.html`.
* Replace `{% include main.html %}` with `{% render 'main.html' %}` in `index.html` and `learning-pygame-zero.html`.
* Replace `{% include footer.html %}` with `{% render 'footer.html' %}` in `index.html`, `learning-pygame-zero.html`, and `_layouts/default.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HeathmontGameDesign/heathmontgamedesign.github.io/pull/5?shareId=2b0420a0-ae98-4cb4-b44c-18631fa1995f).